### PR TITLE
feat: add availability to use HTTPS connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ for [http.request](https://nodejs.org/api/http.html#http_http_request_options_ca
  * **auth**:     authentication as `user:password`, optional
  * **host**:     host to connect, can contain port name
  * **pathname**: pathname of ClickHouse server or `/` if omited,
+ * **port**:     port number,
+ * **protocol**: "https:" or "http:", default "http:".
 
 `queryOptions` object can contain any option from Settings (docs:
 [en](https://clickhouse.yandex/docs/en/operations/settings/index.html)

--- a/src/clickhouse.js
+++ b/src/clickhouse.js
@@ -1,4 +1,5 @@
 var http = require ('http');
+var https = require('https');
 var url  = require ('url');
 var qs   = require ('querystring');
 var util = require ('util');
@@ -171,8 +172,8 @@ function httpRequest (reqParams, reqData, cb) {
 	var stream = new RecordStream ({
 		format: reqData.format
 	});
-
-	var req = http.request (reqParams, httpResponseHandler.bind (
+	var requestInstance = reqParams.protocol === 'https:' ? https : http;
+	var req = requestInstance.request (reqParams, httpResponseHandler.bind (
 		this, stream, reqParams, reqData, cb
 	));
 


### PR DESCRIPTION
It would be great to have the ability to uses secure HTTPS connection in order to use this driver for production env.