### PR TITLE
fix escaping backslashes problem

### DIFF
--- a/src/process-db-value.js
+++ b/src/process-db-value.js
@@ -61,7 +61,7 @@ var ALIASES = {
 }
 
 var ESCAPE_STRING = {
-	TSV: function (v, quote) {return v.replace (/\\/g, '\\').replace(/\t/g, '\\t').replace(/\n/g, '\\n')},
+	TSV: function (v, quote) {return v.replace (/\\/g, '\\\\').replace(/\t/g, '\\t').replace(/\n/g, '\\n')},
 	CSV: function (v, quote) {return v.replace (/\"/g, '""')},
 }
 

--- a/test/06-encode-value.js
+++ b/test/06-encode-value.js
@@ -1,0 +1,12 @@
+var assert = require ('assert');
+var encodeValue = require ('../src/process-db-value').encodeValue;
+
+describe('encode value', function() {
+	it('escaping string backslashes for TSV', function() {
+		var value = '{"key1":\t"{\"key2\":\"<some \\"attr\\">With tabulated \\t and line bracking \\n</some>\"}"\n}';
+		var expected = '{"key1":\\t"{"key2":"<some \\\\"attr\\\\">With tabulated \\\\t and line bracking \\\\n</some>\"}"\\n}';
+		var actual = encodeValue(undefined, value, 'TSV');
+
+		assert.equal(actual, expected);
+  })
+})


### PR DESCRIPTION
The pull request fix problem with escaping backslashes

In code we have:
`v.replace (/\\/g, '\\')`

Its mean: please replace each one backslash with one backslash
Because JS has following rules for backslashes in strings and regular expressions

`\` — always escapes the next character
`\\` — always mean one backslash

So for replacing one backslash with two backslashes, we need double this one in second parameters of replace function

`v.replace (/\\/g, '\\') -> v.replace (/\\/g, '\\\\')`