### PR TITLE
Fix confusing promise interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ for driver or query (BEWARE: not works as expected, use TSV):
 ```javascript
 
 var csvStream = fs.createReadStream ('data.csv');
-var clickhouseStream = clickHouse.query (statement, {inputFormat: CSV});
+var clickhouseStream = ch.query (statement, {inputFormat: CSV});
 
 csvStream.pipe (clickhouseStream);
 
@@ -220,6 +220,12 @@ If you ever need to store rows (in arrays) and send preformatted data, you can d
 ClickHouse also supports [JSONEachRow](https://clickhouse.yandex/docs/en/formats/jsoneachrow.html) format
 which can be useful to insert javascript objects if you have such recordset.
 
+```js
+const stream = ch.query (statement, {format: 'JSONEachRow'})
+
+stream.write (object) // Do write as many times as possible
+stream.end () // And don't forget to finish insert query
+```
 
 ## Memory size
 

--- a/README.md
+++ b/README.md
@@ -153,9 +153,31 @@ a standard node `(error, result)` signature.
 You should have at least one error handler listening. Via callbacks or via stream errors.
 If you have callback and stream listener, you'll have error notification in both listeners.
 
-### clickHouse.querying (statement, [options]).then (…)
+## Promise interface
 
-Promise interface. Similar to the callback one.
+Promise interface **is not recommended** for `INSERT` and `SELECT` queries.
+* `INSERT` cannot bulk load data with promise interface
+* `SELECT` will collect entire query result in the memory
+
+With promise interface query result are parsed snchronously.
+This means that large query result in promise interface:
+* Will snchronously block JS thread/event loop
+* May lead to memory leaks in your app
+
+Use it only for queries where resulting data size is is known and extreemly small.<br/>
+The good cases to use it is `DESCRIBE TABLE` or `EXISTS TABLE`
+
+### clickHouse.querying (statement, [options]).then (…)
+Return `promise`, that will be resolved with entire query result.
+This is an alias to `ch.query(query, {syncParser: true}, (error, data) => {})`
+
+Usage:
+```js
+  ch.querying ("SELECT 1").then((result) => console.log(result.data))
+  // [ [ 1 ] ]
+  ch.querying ("DESCRIBE TABLE system.numbers", {dataObjects: true}).then((result) => console.log(result.data))
+  // [ { name: 'number', type: 'UInt64', default_type: '', default_expression: '' } ]
+```
 
 ### clickHouse.ping (function (err, response) {})
 
@@ -216,10 +238,3 @@ In this case whole JSON response from the server will be read into memory,
 then parsed into memory hogging your CPU. Default parser will parse server response
 line by line and emits events. This is slower, but much more memory and CPU efficient
 for larger datasets.
-
-## Promise interface
-
-Promise interface have some restrictions. It is not recommended to use this interface
-for `INSERT` and `SELECT` queries. For the `INSERT` you cannot bulk load data via stream,
-`SELECT` will collect all the records in the memory. For simple usage where data size
-is controlled it is ok.

--- a/src/clickhouse.js
+++ b/src/clickhouse.js
@@ -325,7 +325,9 @@ ClickHouse.prototype.query = function (chQuery, options, cb) {
 ClickHouse.prototype.querying = function (chQuery, options) {
 
 	return new Promise (function (resolve, reject) {
-		var stream = this.query (chQuery, options, function (err, data) {
+		// Force override `syncParser` option when using promise api
+		const queryOptions = Object.assign ({}, options, {syncParser: true})
+		var stream = this.query (chQuery, queryOptions, function (err, data) {
 			if (err)
 				return reject (err);
 			resolve (data);

--- a/test/05-insert.js
+++ b/test/05-insert.js
@@ -95,6 +95,11 @@ describe ("insert data", function () {
 		});
 	});
 
+	it ("inserts some data using promise", function () {
+		var ch = new ClickHouse ({host: host, port: port});
+		return ch.querying ("INSERT INTO t VALUES (1),(2),(3)", {queryOptions: {database: dbName}});
+	});
+
 	it ("creates a table 2", function (done) {
 		var ch = new ClickHouse ({host: host, port: port, queryOptions: {database: dbName}});
 		ch.query ("CREATE TABLE t2 (a UInt8, b Float32, x Nullable(String), z DateTime) ENGINE = Memory", function (err, result) {


### PR DESCRIPTION
Иван, спасибо большое за этот драйвер!
Он очень хорошо продуман, удобен и функционален!

### Problem description:
When we using any promise api, we expect to get some execution result when promise resolved.
The good way to use promise interface is, for example, `DESCRIBE` queries.
```js
ch.querying ("DESCRIBE TABLE system.numbers").then(console.log)
```
```js
{ rows: 1, statistics: { … }, meta: [ … ], transferred: 377 }
```
But there is no way to access `data`.

I've found that `syncParser: true` option is [used for same case it tests](https://github.com/apla/node-clickhouse/blob/v/1.5.3/test/04-select.js#L51)
```js
ch.querying ("DESCRIBE TABLE system.numbers", {syncParser: true}).then(console.log)
```
```js
{ meta: [ … ], data: [ … ], rows: 1, statistics: { … }, transferred: 377 }
```

#### So, we've forced to always use `syncParser: true` option in every `.querying` call.

### Problem conclusion
I thins it was very confusing and not transparent to understand.
And this is why i decided to fix this =)

### Possible way to improve
I think always use `syncParser: true` for promise is enough, because there is no difference where to collect buffer with entire query result, inside `http.request` handler itself or buffer defined in our code.


I've like your notice about promise interface in readme, but i think it must be more convincing.
So, i've added "some scary words" to this notice

Fast link to preview:
https://github.com/nezed/node-clickhouse/blob/feature/confusing-promise/README.md#promise-interface