### PR TITLE
Add destroy to RecordStream

### DIFF
--- a/src/streams.js
+++ b/src/streams.js
@@ -146,9 +146,9 @@ RecordStream.prototype._write = function _write (chunk, enc, cb) {
 
 };
 
-RecordStream.prototype._destroy = function _destroy(err, cb) {
+RecordStream.prototype._destroy = function _destroy (err, cb) {
 	
-	process.nextTick(function() {
+	process.nextTick (function () {
 		RecordStream.super_.prototype._destroy.call (this, err, function (destroyErr) {
 			this.req.destroy (err);
 			cb (destroyErr || err);

--- a/src/streams.js
+++ b/src/streams.js
@@ -146,6 +146,16 @@ RecordStream.prototype._write = function _write (chunk, enc, cb) {
 
 };
 
+RecordStream.prototype._destroy = function _destroy(err, cb) {
+	
+	process.nextTick(function() {
+		RecordStream.super_.prototype._destroy.call (this, err, function (destroyErr) {
+			this.req.destroy (err);
+			cb (destroyErr || err);
+		}.bind (this));
+	}.bind (this));
+}
+
 RecordStream.prototype.end = function end (chunk, enc, cb) {
 
 	RecordStream.super_.prototype.end.call (this, chunk, enc, function () {

--- a/test/04-select.js
+++ b/test/04-select.js
@@ -202,12 +202,13 @@ describe ("select data from database", function () {
 			return;
 		}
 
-		var ch = new ClickHouse({ host: host, port: port, useQueryString: true });
+		var ch = new ClickHouse ({host: host, port: port});
 		var rows = [];
 		var limit = 10000;
 		var stream = ch.query ("SELECT number FROM system.numbers LIMIT " + limit, function () {
 			assert (stream.destroyed);
 			assert (rows.length < limit);
+
 			done ();
 		});
 
@@ -215,8 +216,8 @@ describe ("select data from database", function () {
 			rows.push (row);
 		});
 
-		stream.once ('data', function() {
-			stream.destroy();			
+		stream.once ('data', function () {
+			stream.destroy ();
 		});
 	});
 });


### PR DESCRIPTION
Node.js introduced the `destroy` method for streams, which is missing from the current `RecordStream` implementation

We ran into this issue when attempting to prematurely end a clickhouse `RecordStream` generated by a querying a large dataset. The app process "hanged" until force closed or the query stream finished pushing data.

Some reference links:
https://nodejs.org/docs/latest-v8.x/api/stream.html#stream_readable_destroy_error
https://medium.com/@CWMma/whats-new-for-streams-in-node-8-736d431083df