### PR TITLE
Fix confusing auth params

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Synopsis
 ---
 
 ```javascript
-var ch = new ClickHouse ({host: clickhouse.host, port: 8123, auth: "user:password"});
+var ch = new ClickHouse ({host: clickhouse.host, port: 8123, user, password});
 // or
 var ch = new ClickHouse (clickhouse.host);
 
@@ -96,7 +96,8 @@ If you provide options as a string, they are assumed as a host parameter in conn
 Connection options (accept all options documented
 for [http.request](https://nodejs.org/api/http.html#http_http_request_options_callback)):
 
- * **auth**:     authentication as `user:password`, optional
+ * **user**:     authentication user, optional
+ * **password**:     authentication password, optional
  * **host**:     host to connect, can contain port name
  * **pathname**: pathname of ClickHouse server or `/` if omited,
  * **port**:     port number,

--- a/src/clickhouse.js
+++ b/src/clickhouse.js
@@ -13,6 +13,8 @@ var JSONStream   = require ('./streams').JSONStream;
 
 var parseError = require ('./parse-error');
 
+var NATIVE_HTTP_OPTIONS = require ('./consts').NATIVE_HTTP_OPTIONS
+
 function httpResponseHandler (stream, reqParams, reqData, cb, response) {
 	var str;
 	var error;
@@ -183,7 +185,7 @@ function httpRequest (reqParams, reqData, cb) {
 			stream.emit ('error', e);
 		return cb && cb (e);
   });
-  
+
   req.on('timeout', function (e) {
     req.abort();
   })
@@ -217,10 +219,15 @@ ClickHouse.prototype.getReqParams = function () {
 	var urlObject = {};
 
 	// avoid to set defaults - node http module is not happy
-	"protocol auth host hostname port path localAddress headers agent createConnection timeout".split (" ").forEach (function (k) {
-		if (this.options[k] !== undefined)
+	NATIVE_HTTP_OPTIONS.forEach (function (k) {
+		if (this.options.hasOwnProperty(k))
 			urlObject[k] = this.options[k];
 	}, this);
+	if (this.options.hasOwnProperty('user') || this.options.hasOwnProperty('password')) {
+		urlObject.auth = encodeURIComponent(this.options.user || 'default')
+			+ ':'
+			+ encodeURIComponent(this.options.password || '')
+	}
 
 	urlObject.method = 'POST';
 

--- a/src/consts.js
+++ b/src/consts.js
@@ -1,0 +1,13 @@
+exports.NATIVE_HTTP_OPTIONS = [
+  'protocol',
+  'auth',
+  'host',
+  'hostname',
+  'port',
+  'path',
+  'localAddress',
+  'headers',
+  'agent',
+  'createConnection',
+  'timeout',
+]

--- a/test/02-real-server.js
+++ b/test/02-real-server.js
@@ -64,6 +64,11 @@ describe ("real server", function () {
 		});
 	});
 
+	it ("authorises by credentials", function () {
+		var ch = new ClickHouse ({host: host, port: port, user: 'default', password: ''});
+		return ch.querying ("SELECT 1");
+	});
+
 	it ("selects from system columns", function (done) {
 		var ch = new ClickHouse ({host: host, port: port});
 		ch.query ("SELECT * FROM system.columns", function (err, result) {


### PR DESCRIPTION
1. Get rid of implicit `auth` format ( Closes #2 )
1. Escape symbols as it must be in URI