### PR TITLE
All existing nodejs http & https request options are now allowed

### DIFF
--- a/src/clickhouse.js
+++ b/src/clickhouse.js
@@ -13,7 +13,7 @@ var JSONStream   = require ('./streams').JSONStream;
 
 var parseError = require ('./parse-error');
 
-var NATIVE_HTTP_OPTIONS = require ('./consts').NATIVE_HTTP_OPTIONS
+var LIBRARY_SPECIFIC_OPTIONS = require ('./consts').LIBRARY_SPECIFIC_OPTIONS;
 
 function httpResponseHandler (stream, reqParams, reqData, cb, response) {
 	var str;
@@ -219,10 +219,12 @@ ClickHouse.prototype.getReqParams = function () {
 	var urlObject = {};
 
 	// avoid to set defaults - node http module is not happy
-	NATIVE_HTTP_OPTIONS.forEach (function (k) {
-		if (this.options.hasOwnProperty(k))
-			urlObject[k] = this.options[k];
-	}, this);
+	for (var name of Object.keys(this.options)) {
+		if (!LIBRARY_SPECIFIC_OPTIONS.has(name)) {
+			urlObject[name] = this.options[name];
+		}
+	}
+
 	if (this.options.hasOwnProperty('user') || this.options.hasOwnProperty('password')) {
 		urlObject.auth = encodeURIComponent(this.options.user || 'default')
 			+ ':'

--- a/src/consts.js
+++ b/src/consts.js
@@ -1,13 +1,16 @@
-exports.NATIVE_HTTP_OPTIONS = [
-  'protocol',
-  'auth',
-  'host',
-  'hostname',
-  'port',
-  'path',
-  'localAddress',
-  'headers',
-  'agent',
-  'createConnection',
-  'timeout',
-]
+exports.LIBRARY_SPECIFIC_OPTIONS = new Set([
+  // "Auth" shorthand
+  'user',
+  'password',
+
+  // Database settings go to query string
+  'queryOptions',
+
+  // Driver options
+  'dataObjects',
+  'format',
+  'syncParser',
+  'omitFormat',
+  'readonly',
+  'useQueryString'
+]);


### PR DESCRIPTION
This allows using clickhouse installations with self-signed certificates via `rejectUnauthorized: false` option or by setting correct `ca` option.