### PR TITLE
Rename useQueryString to readonly

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ var options = {
     profile: "web",
     database: "test"
   },
-  omitFormat: false
+  omitFormat: false,
+  readonly: true,
 };
 
 var clickHouse = new ClickHouse (options);
@@ -127,6 +128,7 @@ Driver options:
  which returns dataset. Currently `SELECT|SHOW|DESC|DESCRIBE|EXISTS\s+TABLE`.
  You can change this behaviour by providing this option. In this case you should
  add `FORMAT JSONCompact` by yourself. Should be detected automatically. Default `false`;
+ * **readonly**: tells driver to send query with HTTP GET method. Same as [`readonly=1` setting](https://clickhouse.yandex/docs/en/operations/settings/permissions_for_queries/#settings_readonly). [More details](https://clickhouse.yandex/docs/en/interfaces/http/)
 
 
 ### var stream = clickHouse.query (statement, [options], [callback])

--- a/src/clickhouse.js
+++ b/src/clickhouse.js
@@ -248,7 +248,7 @@ ClickHouse.prototype.query = function (chQuery, options, cb) {
 	options.omitFormat  = options.omitFormat  || this.options.omitFormat  || false;
 	options.dataObjects = options.dataObjects || this.options.dataObjects || false;
 	options.format      = options.format      || this.options.format      || null;
-	options.readonly    = options.readonly    || this.options.readonly    || false;
+	options.readonly    = options.readonly    || this.options.readonly    || this.options.useQueryString || false;
 
 	// we're adding `queryOptions` passed for constructor if any
 	var queryObject = Object.assign ({}, this.options.queryOptions, options.queryOptions);

--- a/src/clickhouse.js
+++ b/src/clickhouse.js
@@ -183,7 +183,7 @@ function httpRequest (reqParams, reqData, cb) {
 			stream.emit ('error', e);
 		return cb && cb (e);
   });
-  
+
   req.on('timeout', function (e) {
     req.abort();
   })
@@ -248,6 +248,7 @@ ClickHouse.prototype.query = function (chQuery, options, cb) {
 	options.omitFormat  = options.omitFormat  || this.options.omitFormat  || false;
 	options.dataObjects = options.dataObjects || this.options.dataObjects || false;
 	options.format      = options.format      || this.options.format      || null;
+	options.readonly    = options.readonly    || this.options.readonly    || false;
 
 	// we're adding `queryOptions` passed for constructor if any
 	var queryObject = Object.assign ({}, this.options.queryOptions, options.queryOptions);
@@ -311,7 +312,7 @@ ClickHouse.prototype.query = function (chQuery, options, cb) {
 	reqData.format = options.format;
 
 	// use query string to submit ClickHouse query — useful to mock CH server
-	if (this.options.useQueryString) {
+	if (options.readonly) {
 		queryObject.query = chQuery + ((options.omitFormat) ? '' : ' FORMAT ' + options.format + formatEnding);
 		reqParams.method = 'GET';
 	} else {

--- a/test/01-simulated.js
+++ b/test/01-simulated.js
@@ -107,7 +107,7 @@ describe ("simulated queries", function () {
 	});
 
 	it ("selects using callback", function (done) {
-		var ch = new ClickHouse ({host: host, port: port, useQueryString: true});
+		var ch = new ClickHouse ({host: host, port: port, readonly: true});
 		ch.query ("SELECT 1", {syncParser: true}, function (err, result) {
 			assert (!err);
 			assert (result.meta, "result should be Object with `data` key to represent rows");
@@ -118,7 +118,7 @@ describe ("simulated queries", function () {
 	});
 
 	it ("selects numbers using callback", function (done) {
-		var ch = new ClickHouse ({host: host, port: port, useQueryString: true});
+		var ch = new ClickHouse ({host: host, port: port, readonly: true});
 		ch.query ("SELECT number FROM system.numbers LIMIT 10", {syncParser: true}, function (err, result) {
 			assert (!err);
 			assert (result.data, "result should be Object with `data` key to represent rows");
@@ -135,7 +135,7 @@ describe ("simulated queries", function () {
 	});
 
 	it ("selects numbers using stream", function (done) {
-		var ch = new ClickHouse ({host: host, port: port, useQueryString: true});
+		var ch = new ClickHouse ({host: host, port: port, readonly: true});
 		var rows = [];
 		var stream = ch.query ("SELECT number FROM system.numbers LIMIT 10", function (err, result) {
 			assert (!err);

--- a/test/02-real-server.js
+++ b/test/02-real-server.js
@@ -51,7 +51,7 @@ describe ("real server", function () {
 	});
 
 	it ("returns error", function (done) {
-		var ch = new ClickHouse ({host: host, port: port, useQueryString: true});
+		var ch = new ClickHouse ({host: host, port: port, readonly: true});
 		var stream = ch.query ("ABCDEFGHIJKLMN", {syncParser: true}, function (err, result) {
 			// assert (err);
 			// done ();

--- a/test/03-errors.js
+++ b/test/03-errors.js
@@ -14,7 +14,7 @@ describe ("error parsing", function () {
 		dbCreated = false;
 
 	it ("will not throw on http error", function (done) {
-		var ch = new ClickHouse ({host: host, port: 59999, useQueryString: true});
+		var ch = new ClickHouse ({host: host, port: 59999, readonly: true});
 		var stream = ch.query ("ABCDEFGHIJKLMN", {syncParser: true}, function (err, result) {
 			// assert (err);
 			// done ();
@@ -26,7 +26,7 @@ describe ("error parsing", function () {
 	});
 
 	it ("returns error for unknown sql", function (done) {
-		var ch = new ClickHouse ({host: host, port: port, useQueryString: true});
+		var ch = new ClickHouse ({host: host, port: port, readonly: true});
 		var stream = ch.query ("ABCDEFGHIJKLMN", {syncParser: true}, function (err, result) {
 			// assert (err);
 			// done ();
@@ -44,7 +44,7 @@ describe ("error parsing", function () {
 	});
 
 	it ("returns error with line/col for sql with garbage", function (done) {
-		var ch = new ClickHouse ({host: host, port: port, useQueryString: true});
+		var ch = new ClickHouse ({host: host, port: port, readonly: true});
 		var stream = ch.query ("CREATE\n\t\tABCDEFGHIJKLMN", {syncParser: true}, function (err, result) {
 			// assert (err);
 			// done ();
@@ -62,7 +62,7 @@ describe ("error parsing", function () {
 	});
 
 	it ("returns error for empty sql", function (done) {
-		var ch = new ClickHouse ({host: host, port: port, useQueryString: true});
+		var ch = new ClickHouse ({host: host, port: port, readonly: true});
 
 		function countCallbacks (err) {
 			countCallbacks.count = (countCallbacks.count || 0) + 1;
@@ -94,10 +94,9 @@ describe ("error parsing", function () {
 	});
 
 	it ("returns error for unknown table", function (done) {
-		var ch = new ClickHouse ({host: host, port: port, useQueryString: true});
+		var ch = new ClickHouse ({host: host, port: port, readonly: true});
 		var stream = ch.query ("SELECT * FROM xxx", {syncParser: true}, function (err, result) {
-			// assert (err);
-			// done ();
+			assert (err);
 		});
 
 		stream.on ('error', function (err) {
@@ -110,6 +109,13 @@ describe ("error parsing", function () {
 
 			done();
 		});
+	});
+
+	it ("returns error for writing in readonly mode", function (done) {
+		var ch = new ClickHouse ({host: host, port: port});
+		ch.querying ("CREATE TABLE xxx (a UInt8) ENGINE = Memory()", {readonly: true})
+			.then(() => done('Should fail in readonly mode'))
+			.catch(() => done())
 	});
 
 

--- a/test/04-select.js
+++ b/test/04-select.js
@@ -10,7 +10,7 @@ describe ("select data from database", function () {
 		dbCreated = false;
 
 	it ("selects using callback", function (done) {
-		var ch = new ClickHouse ({host: host, port: port, useQueryString: true});
+		var ch = new ClickHouse ({host: host, port: port, readonly: true});
 		ch.query ("SELECT 1", {syncParser: true}, function (err, result) {
 			assert (!err);
 			assert (result.meta, "result should be Object with `data` key to represent rows");
@@ -30,7 +30,7 @@ describe ("select data from database", function () {
 	});
 
 	it ("selects numbers using callback", function (done) {
-		var ch = new ClickHouse ({host: host, port: port, useQueryString: true});
+		var ch = new ClickHouse ({host: host, port: port, readonly: true});
 		ch.query ("SELECT number FROM system.numbers LIMIT 10", {syncParser: true}, function (err, result) {
 			assert (!err);
 			assert (result.meta, "result should be Object with `data` key to represent rows");
@@ -47,7 +47,7 @@ describe ("select data from database", function () {
 	});
 
 	it ("selects numbers using promise should already have parsed data", function () {
-		var ch = new ClickHouse ({host: host, port: port, useQueryString: true});
+		var ch = new ClickHouse ({host: host, port: port, readonly: true});
 		return ch.querying ("SELECT number FROM system.numbers LIMIT 10").then (function (result) {
 			assert (result.meta, "result should be Object with `data` key to represent rows");
 			assert (result.data, "result should be Object with `meta` key to represent column info");
@@ -63,7 +63,7 @@ describe ("select data from database", function () {
 	});
 
 	it ("selects numbers as dataObjects using promise", function () {
-		var ch = new ClickHouse ({host: host, port: port, useQueryString: true, dataObjects: true});
+		var ch = new ClickHouse ({host: host, port: port, readonly: true, dataObjects: true});
 		return ch.querying ("SELECT number FROM system.numbers LIMIT 10").then (function (result) {
 			assert (result.meta, "result should be Object with `data` key to represent rows");
 			assert (result.data, "result should be Object with `meta` key to represent column info");

--- a/test/90-torture.js
+++ b/test/90-torture.js
@@ -62,7 +62,7 @@ describe ("torturing", function () {
 
 		this.timeout (timeout);
 
-		var ch = new ClickHouse ({host: host, port: port, useQueryString: true});
+		var ch = new ClickHouse ({host: host, port: port, readonly: true});
 		var queryCount = 0;
 		var symbolsTransferred = 0;
 
@@ -95,7 +95,7 @@ describe ("torturing", function () {
 
 		this.timeout (timeout);
 
-		var ch = new ClickHouse ({host: host, port: port, useQueryString: true});
+		var ch = new ClickHouse ({host: host, port: port, readonly: true});
 		var queryCount = 0;
 		var symbolsTransferred = 0;
 
@@ -127,7 +127,7 @@ describe ("torturing", function () {
 
 		this.timeout (timeout);
 
-		var ch = new ClickHouse ({host: host, port: port, useQueryString: true});
+		var ch = new ClickHouse ({host: host, port: port, readonly: true});
 		var queryCount = 0;
 		var symbolsTransferred = 0;
 
@@ -159,7 +159,7 @@ describe ("torturing", function () {
 
 		this.timeout (timeout);
 
-		var ch = new ClickHouse ({host: host, port: port, useQueryString: true});
+		var ch = new ClickHouse ({host: host, port: port, readonly: true});
 		var queryCount = 0;
 		var symbolsTransferred = 0;
 
@@ -191,7 +191,7 @@ describe ("torturing", function () {
 
 		this.timeout (timeout);
 
-		var ch = new ClickHouse ({host: host, port: port, useQueryString: true});
+		var ch = new ClickHouse ({host: host, port: port, readonly: true});
 		var queryCount = 0;
 		var symbolsTransferred = 0;
 
@@ -223,7 +223,7 @@ describe ("torturing", function () {
 
 		this.timeout (timeout);
 
-		var ch = new ClickHouse ({host: host, port: port, useQueryString: true});
+		var ch = new ClickHouse ({host: host, port: port, readonly: true});
 		var queryCount = 0;
 		var symbolsTransferred = 0;
 


### PR DESCRIPTION
### Motivation:
- Provide easy way to turn query into readonly mode.
- `useQueryString` turns connection in readonly mode, which may be unexpected.
- `{ queryOptions: { readonly: true } }` are ignored by CH, which may be unexpected.