### PR TITLE
Make readme better

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Doesn't requires authorization.
 ##### `callback: (error, result) => void`
 Will be called upon completion.
 
+<br />
+
 ## Promise interface
 
 Promise interface **is not recommended** for `INSERT` and `SELECT` queries.
@@ -140,10 +142,12 @@ Promise interface for `ping`
 
 ##### Returns: `Promise`
 
-Notes
+<br />
+
+How it works
 -----
 
-## Bulk data loading with `INSERT` statements
+### Bulk data loading with `INSERT` statements
 
 `INSERT` can be used for bulk data loading. There is a 2 formats easily implementable
 with javascript: CSV and TabSeparated/TSV.
@@ -180,7 +184,7 @@ stream.write(object) // Do write as many times as possible
 stream.end() // And don't forget to finish insert query
 ```
 
-## Memory size
+### Memory size
 
 You can read all the records into memory in single call like this:
 
@@ -197,6 +201,8 @@ In this case whole JSON response from the server will be read into memory,
 then parsed into memory hogging your CPU. Default parser will parse server response
 line by line and emits events. This is slower, but much more memory and CPU efficient
 for larger datasets.
+
+<br />
 
 ## Examples
 #### Selecting with stream

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The good cases to use it is `DESCRIBE TABLE` or `EXISTS TABLE`
 ### `clickHouse.querying(query, [options])`
 This is an alias to `ch.query(query, { syncParser: true }, (error, data) => {})`
 ##### `options: Options`
-The same as for `constructor`, excluding connection options.
+The same [`Options`](README.md#options), excluding connection options.
 
 ##### Returns: `Promise`
 Will be resolved with entire query result.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ API
 | `timeout`, <br /> `headers`, <br /> `agent`, <br /> `localAddress`, <br /> `servername`, <br /> etc… |   |   |  Any [http.request](https://nodejs.org/api/http.html#http_http_request_options_callback) or [https.request](https://nodejs.org/api/https.html#https_https_request_options_callback) options are also available.
 
 <!--
-This are mostly unuseful for end user
+This are dangerous for using by end user
 
 | `syncParser`     |          | `false`       | **Not recommended for large amounts of data!** <br /> Collects all data, then parse entire response. <br /> May be faster, but for large datasets all your dataset goes into memory (actually, entire response + entire dataset).
 # Might be completely replaced with promise interface.
@@ -57,11 +57,11 @@ This are mostly unuseful for end user
 ```javascript
 const ch = new ClickHouse({
   host: "clickhouse.msk",
+  dataObjects: true,
   queryOptions: {
     profile: "web",
     database: "test",
   },
-  omitFormat: false,
 })
 ```
 
@@ -185,7 +185,7 @@ You can read all the records into memory in single call like this:
 ```javascript
 
 var ch = new ClickHouse({ host: host, port: port })
-ch.query("SELECT number FROM system.numbers LIMIT 10", { syncParser: true }, (err, result) => {
+ch.querying("SELECT number FROM system.numbers LIMIT 10", (err, result) => {
   // result will contain all the data you need
 })
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,11 @@
-Database interface for http://clickhouse.yandex
+Simple and powerful interface for [ClickHouse](https://clickhouse.yandex/) [![travis](https://travis-ci.org/apla/node-clickhouse.svg)](https://travis-ci.org/apla/node-clickhouse) [![codecov](https://codecov.io/gh/apla/node-clickhouse/branch/master/graph/badge.svg)](https://codecov.io/gh/apla/node-clickhouse)
 ===
-
 ```sh
 npm install @apla/clickhouse
 ```
 
-[![travis](https://travis-ci.org/apla/node-clickhouse.svg)](https://travis-ci.org/apla/node-clickhouse)
-[![codecov](https://codecov.io/gh/apla/node-clickhouse/branch/master/graph/badge.svg)](https://codecov.io/gh/apla/node-clickhouse)
-
 Synopsis
 ---
-Basic API:
-
 ```javascript
 const ClickHouse = require('@apla/clickhouse')
 const ch = new ClickHouse({ host, port, user, password })

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Examples:
 API
 ---
 
-### `new ClickHouse (options: Options)`
+### `new ClickHouse(options: Options)`
 
 #### `Options`
 
@@ -44,7 +44,7 @@ API
 | `pathname`       |          | `/`           | Pathname of ClickHouse server.
 | `port`           |          | `8123`        | Server port number.
 | `protocol`       |          | `'http:'`     | `'https:'` or `'http:'`.
-| `dataObjects`    |          | `false`       | By default (`false`), you'll receive array of values for each row. <br /> If you set `dataObjects: true`, every row will become an object with format: `{fieldName: fieldValue, …}`. <br /> Alias to `format: 'JSON'`.
+| `dataObjects`    |          | `false`       | By default (`false`), you'll receive array of values for each row. <br /> If you set `dataObjects: true`, every row will become an object with format: `{ fieldName: fieldValue, … }`. <br /> Alias to `format: 'JSON'`.
 | `format`         |          | `JSONCompact` | Adds the `FORMAT` statement for query if it did not have one. <br /> Specifies format of [selected](https://clickhouse.yandex/docs/en/query_language/select/#format-clause) or [inserted](https://clickhouse.yandex/docs/en/query_language/insert_into/#insert) data. <br /> See ["Formats for input and output data"](https://clickhouse.yandex/docs/en/interfaces/formats/#formats) to find out possible values.
 | `queryOptions`   |          |               | Object, can contain any ClickHouse option from [Settings](https://clickhouse.yandex/docs/en/operations/settings/index.html), [Restrictions](https://clickhouse.yandex/docs/en/operations/settings/query_complexity/) and [Permissions](https://clickhouse.yandex/docs/en/operations/settings/permissions_for_queries/). <br /> See [example](README.md#settings-for-connection).
 | `timeout`, <br /> `headers`, <br /> `agent`, <br /> `localAddress`, <br /> `servername`, <br /> etc… |   |   |  Any [http.request](https://nodejs.org/api/http.html#http_http_request_options_callback) or [https.request](https://nodejs.org/api/https.html#https_https_request_options_callback) options are also available.
@@ -61,7 +61,7 @@ This are mostly unuseful for end user
 
 ##### Options example:
 ```javascript
-const ch = new ClickHouse ({
+const ch = new ClickHouse({
   host: "clickhouse.msk",
   queryOptions: {
     profile: "web",
@@ -103,7 +103,7 @@ Examples:
 - [Selecting with stream](README.md#selecting-with-stream)
 - [Inserting with stream](README.md#inserting-with-stream)
 
-### `clickHouse.ping (callback)`
+### `clickHouse.ping(callback)`
 Sends an empty query.
 Doesn't requires authorization.
 
@@ -124,8 +124,8 @@ This means that large query result in promise interface:
 Use it only for queries where resulting data size is is known and extremely small.<br/>
 The good cases to use it is `DESCRIBE TABLE` or `EXISTS TABLE`
 
-### `clickHouse.querying (query, [options])`
-This is an alias to `ch.query(query, {syncParser: true}, (error, data) => {})`
+### `clickHouse.querying(query, [options])`
+This is an alias to `ch.query(query, { syncParser: true }, (error, data) => {})`
 ##### `options: Options`
 The same as for `constructor`, excluding connection options.
 
@@ -135,13 +135,13 @@ Will be resolved with entire query result.
 
 Usage:
 ```js
-  ch.querying ("SELECT 1").then((result) => console.log(result.data))
+  const { data } = ch.querying("SELECT 1").then((result) => console.log(result.data))
   // [ [ 1 ] ]
-  ch.querying ("DESCRIBE TABLE system.numbers", {dataObjects: true}).then((result) => console.log(result.data))
+  const { data } = await ch.querying("DESCRIBE TABLE system.numbers", { dataObjects: true })
   // [ { name: 'number', type: 'UInt64', default_type: '', default_expression: '' } ]
 ```
 
-### `clickHouse.pinging ()`
+### `clickHouse.pinging()`
 Promise interface for `ping`
 
 ##### Returns: `Promise`
@@ -160,10 +160,10 @@ for driver or query (BEWARE: not works as expected, use TSV):
 
 ```javascript
 
-var csvStream = fs.createReadStream ('data.csv');
-var clickhouseStream = ch.query (statement, {format: CSV});
+var csvStream = fs.createReadStream('data.csv')
+var clickhouseStream = ch.query(statement, { format: CSV })
 
-csvStream.pipe (clickhouseStream);
+csvStream.pipe(clickhouseStream)
 
 ```
 
@@ -180,10 +180,10 @@ ClickHouse also supports [JSONEachRow](https://clickhouse.yandex/docs/en/formats
 which can be useful to insert javascript objects if you have such recordset.
 
 ```js
-const stream = ch.query (statement, {format: 'JSONEachRow'})
+const stream = ch.query(statement, { format: 'JSONEachRow' })
 
-stream.write (object) // Do write as many times as possible
-stream.end () // And don't forget to finish insert query
+stream.write(object) // Do write as many times as possible
+stream.end() // And don't forget to finish insert query
 ```
 
 ## Memory size
@@ -192,10 +192,10 @@ You can read all the records into memory in single call like this:
 
 ```javascript
 
-var ch = new ClickHouse ({host: host, port: port});
-ch.query ("SELECT number FROM system.numbers LIMIT 10", {syncParser: true}, function (err, result) {
+var ch = new ClickHouse({ host: host, port: port })
+ch.query("SELECT number FROM system.numbers LIMIT 10", { syncParser: true }, (err, result) => {
   // result will contain all the data you need
-});
+})
 
 ```
 
@@ -207,7 +207,7 @@ for larger datasets.
 ## Examples
 #### Selecting with stream
 ```javascript
-const readableStream = ch.query (
+const readableStream = ch.query(
   'SELECT * FROM system.contributors FORMAT JSONEachRow',
   (err, result) => {},
 )
@@ -218,7 +218,7 @@ readableStream.pipe(writableStream)
 #### Inserting with stream
 ```javascript
 const readableStream = fs.createReadStream('./x.csv')
-const writableStream = ch.query ('INSERT INTO table FORMAT CSV', (err, result) => {})
+const writableStream = ch.query('INSERT INTO table FORMAT CSV', (err, result) => {})
 readableStream.pipe(writableStream)
 ```
 
@@ -230,7 +230,7 @@ const writableStream = ch.query(`INSERT INTO table FORMAT TSV`, (err) => {
 })
 
 // data will be formatted for you
-writableStream.write([1, 2.22, "erbgwerg", new Date ()])
+writableStream.write([1, 2.22, "erbgwerg", new Date()])
 
 // prepare data yourself
 writableStream.write("1\t2.22\terbgwerg\t2017-07-17 17:17:17")
@@ -248,7 +248,7 @@ const stream = ch.query("SELECT * FROM system.numbers LIMIT 10000000")
 
 stream.on('metadata', (columns) => { /* do something with column list */ })
 
-let rows = [];
+let rows = []
 stream.on('data', (row) => rows.push(row))
 
 stream.on('error', (err) => { /* handler error */ })
@@ -259,7 +259,7 @@ stream.on('end', () => {
     stream.supplemental.rows,
     stream.supplemental.rows_before_limit_at_least, // how many rows in result are set without windowing
   )
-});
+})
 ```
 
 #### Inserting large dataset:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ API
 | `dataObjects`    |          | `false`       | By default (`false`), you'll receive array of values for each row. <br /> If you set `dataObjects: true`, every row will become an object with format: `{ fieldName: fieldValue, … }`. <br /> Alias to `format: 'JSON'`.
 | `format`         |          | `JSONCompact` | Adds the `FORMAT` statement for query if it did not have one. <br /> Specifies format of [selected](https://clickhouse.yandex/docs/en/query_language/select/#format-clause) or [inserted](https://clickhouse.yandex/docs/en/query_language/insert_into/#insert) data. <br /> See ["Formats for input and output data"](https://clickhouse.yandex/docs/en/interfaces/formats/#formats) to find out possible values.
 | `queryOptions`   |          |               | Object, can contain any ClickHouse option from [Settings](https://clickhouse.yandex/docs/en/operations/settings/index.html), [Restrictions](https://clickhouse.yandex/docs/en/operations/settings/query_complexity/) and [Permissions](https://clickhouse.yandex/docs/en/operations/settings/permissions_for_queries/). <br /> See [example](README.md#settings-for-connection).
+| `readonly`       |          | `false`       | Tells driver to send query with HTTP GET method. Same as [`readonly=1` setting](https://clickhouse.yandex/docs/en/operations/settings/permissions_for_queries/#settings_readonly). [More details](https://clickhouse.yandex/docs/en/interfaces/http/).
 | `timeout`, <br /> `headers`, <br /> `agent`, <br /> `localAddress`, <br /> `servername`, <br /> etc… |   |   |  Any [http.request](https://nodejs.org/api/http.html#http_http_request_options_callback) or [https.request](https://nodejs.org/api/https.html#https_https_request_options_callback) options are also available.
 
 <!--
@@ -58,6 +59,7 @@ This are dangerous for using by end user
 const ch = new ClickHouse({
   host: "clickhouse.msk",
   dataObjects: true,
+  readonly: true,
   queryOptions: {
     profile: "web",
     database: "test",

--- a/README.md
+++ b/README.md
@@ -121,24 +121,18 @@ Use it only for queries where resulting data size is is known and extremely smal
 The good cases to use it is `DESCRIBE TABLE` or `EXISTS TABLE`
 
 ### `clickHouse.querying(query, [options])`
-This is an alias to `ch.query(query, { syncParser: true }, (error, data) => {})`
+Similar to `ch.query(query)` but collects entire response in memory and resolves with complete query result. <br />
+See the [Memory size](README.md#memory-size) section.
 ##### `options: Options`
 The same [`Options`](README.md#options), excluding connection options.
 
 ##### Returns: `Promise`
 Will be resolved with entire query result.
 
-
-Usage:
-```js
-  const { data } = ch.querying("SELECT 1").then((result) => console.log(result.data))
-  // [ [ 1 ] ]
-  const { data } = await ch.querying("DESCRIBE TABLE system.numbers", { dataObjects: true })
-  // [ { name: 'number', type: 'UInt64', default_type: '', default_expression: '' } ]
-```
+Example of [promise interface](README.md#promise-interface).
 
 ### `clickHouse.pinging()`
-Promise interface for `ping`
+Promise interface for [`.ping`](README.md#clickhousepingcallback).
 
 ##### Returns: `Promise`
 
@@ -295,4 +289,17 @@ const stream = ch.query('INSERT INTO table FORMAT TSV', {
     insert_quorum: 2,
   },
 })
+```
+
+#### Promise interface
+```js
+  const ch = new ClickHouse(options)
+  // Check connection to server. Doesn't requires authorization.
+  await ch.pinging()
+```
+```js
+  const { data } = await ch.querying("SELECT 1")
+  // [ [ 1 ] ]
+  const { data } = await ch.querying("DESCRIBE TABLE system.numbers", { dataObjects: true })
+  // [ { name: 'number', type: 'UInt64', default_type: '', default_expression: '' } ]
 ```

--- a/README.md
+++ b/README.md
@@ -11,44 +11,60 @@ npm install @apla/clickhouse
 Synopsis
 ---
 Basic API:
+
 ```javascript
-const ch = new ClickHouse({host: clickhouse.host, port: 8123, user, password})
+const ch = new ClickHouse({ host, port, user, password })
 
-// do the query, callback interface, not recommended for selects
-ch.query("CREATE DATABASE test", (err, data) => {})
+const stream = ch.query("SELECT 1", (err, data) => {})
+stream.pipe(process.stdout)
 
-// promise interface (requires 'util.promisify' for node < 8, Promise shim for node < 4)
-ch.querying("CREATE DATABASE test").then (…)
+// promise interface, not recommended for selects
+// (requires 'util.promisify' for node < 8, Promise shim for node < 4)
+await ch.querying("CREATE DATABASE test")
 ```
-Selecting large dataset:
-```javascript
-// it is better to use stream interface to fetch select results
-const stream = ch.query("SELECT * FROM system.numbers LIMIT 10000000")
 
-stream.on('metadata', (columns) => { /* do something with column list */ })
+<details>
+  <summary>Selecting large dataset:</summary>
+  <p>
 
-let rows = [];
-stream.on('data', (row) => rows.push(row))
+    ```javascript
+    // it is better to use stream interface to fetch select results
+    const stream = ch.query("SELECT * FROM system.numbers LIMIT 10000000")
 
-stream.on('error', (err) => { /* handler error */ })
+    stream.on('metadata', (columns) => { /* do something with column list */ })
 
-stream.on('end', () => {
-  console.log(
-    rows.length,
-    stream.supplemental.rows,
-    stream.supplemental.rows_before_limit_at_least, // how many rows in result are set without windowing
-  )
-});
-```
-Inserting large dataset:
-```javascript
-// insert from file
+    let rows = [];
+    stream.on('data', (row) => rows.push(row))
 
-var tsvStream = fs.createReadStream('data.tsv')
-var clickhouseStream = clickHouse.query('INSERT INTO table FORMAT TSV')
+    stream.on('error', (err) => { /* handler error */ })
 
-tsvStream.pipe(clickhouseStream)
-```
+    stream.on('end', () => {
+      console.log(
+        rows.length,
+        stream.supplemental.rows,
+        stream.supplemental.rows_before_limit_at_least, // how many rows in result are set without windowing
+      )
+    });
+    ```
+  </p>
+</details>
+
+
+<details>
+  <summary>Inserting large dataset:</summary>
+  <p>
+
+    ```javascript
+    // insert from file
+
+    var tsvStream = fs.createReadStream('data.tsv')
+    var clickhouseStream = clickHouse.query('INSERT INTO table FORMAT TSV')
+
+    tsvStream.pipe(clickhouseStream)
+    ```
+
+  </p>
+</details>
 
 
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ for larger datasets.
 <br />
 
 ## Examples
-#### Selecting with stream
+#### Selecting with stream:
 ```javascript
 const readableStream = ch.query(
   'SELECT * FROM system.contributors FORMAT JSONEachRow',
@@ -209,7 +209,7 @@ const writableStream = fs.createWriteStream('./contributors.json')
 readableStream.pipe(writableStream)
 ```
 
-#### Inserting with stream
+#### Inserting with stream:
 ```javascript
 const readableStream = fs.createReadStream('./x.csv')
 const writableStream = ch.query('INSERT INTO table FORMAT CSV', (err, result) => {})
@@ -233,7 +233,7 @@ writableStream.end()
 
 ```
 
-#### Selecting large dataset:</summary>
+#### Selecting large dataset:
 
 ```javascript
 const ch = new ClickHouse(options)
@@ -291,15 +291,15 @@ const stream = ch.query('INSERT INTO table FORMAT TSV', {
 })
 ```
 
-#### Promise interface
+#### Promise interface:
 ```js
-  const ch = new ClickHouse(options)
-  // Check connection to server. Doesn't requires authorization.
-  await ch.pinging()
+const ch = new ClickHouse(options)
+// Check connection to server. Doesn't requires authorization.
+await ch.pinging()
 ```
 ```js
-  const { data } = await ch.querying("SELECT 1")
-  // [ [ 1 ] ]
-  const { data } = await ch.querying("DESCRIBE TABLE system.numbers", { dataObjects: true })
-  // [ { name: 'number', type: 'UInt64', default_type: '', default_expression: '' } ]
+const { data } = await ch.querying("SELECT 1")
+// [ [ 1 ] ]
+const { data } = await ch.querying("DESCRIBE TABLE system.numbers", { dataObjects: true })
+// [ { name: 'number', type: 'UInt64', default_type: '', default_expression: '' } ]
 ```

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ Notes
 with javascript: CSV and TabSeparated/TSV.
 
 CSV is useful for loading from file, thus you can read and `.pipe` into clickhouse
-file contents. To activate CSV parsing you should set `inputFormat` option to `CSV`
-for driver or query (BEWARE: not works as expected, use TSV):
+file contents. <br />
+To activate CSV parsing you should set `format` driver option or query `FORMAT` statement to `CSV`:
 
 ```javascript
 

--- a/README.md
+++ b/README.md
@@ -99,18 +99,9 @@ You should have at least one error handler listening. Via query callback or via 
 After response is processed, you can read a supplemental response data from it, such as row count.
 
 
-
-```javascript
-const readableStream = fs.createReadStream('./x.csv')
-const writableStream = ch.query ('INSERT INTO table FORMAT CSV', (err, result) => {})
-readableStream.pipe(writableStream)
-```
-
-```javascript
-const readableStream = ch.query ('SELECT * FROM system.contributors FORMAT JSON', (err, result) => {})
-const writableStream = fs.createWriteStream('./contributors.json')
-readableStream.pipe(writableStream)
-```
+Examples:
+- [Selecting with stream](README.md#selecting-with-stream)
+- [Inserting with stream](README.md#inserting-with-stream)
 
 ### `clickHouse.ping (callback)`
 Sends an empty query.
@@ -123,12 +114,12 @@ Will be called upon completion.
 
 Promise interface **is not recommended** for `INSERT` and `SELECT` queries.
 * `INSERT` can't do bulk load data with promise interface.
-* `SELECT` will collect entire query result in the memory. See [Memory size](README.md#memory-size).
+* `SELECT` will collect entire query result in the memory. See the [Memory size](README.md#memory-size) section.
 
 With promise interface query result are parsed synchronously.
 This means that large query result in promise interface:
-* Will synchronously block JS thread/event loop
-* May lead to memory leaks in your app
+* Will synchronously block JS thread/event loop.
+* May lead to memory leaks in your app due peak GC loads.
 
 Use it only for queries where resulting data size is is known and extremely small.<br/>
 The good cases to use it is `DESCRIBE TABLE` or `EXISTS TABLE`
@@ -214,6 +205,23 @@ line by line and emits events. This is slower, but much more memory and CPU effi
 for larger datasets.
 
 ## Examples
+#### Selecting with stream
+```javascript
+const readableStream = ch.query (
+  'SELECT * FROM system.contributors FORMAT JSONEachRow',
+  (err, result) => {},
+)
+const writableStream = fs.createWriteStream('./contributors.json')
+readableStream.pipe(writableStream)
+```
+
+#### Inserting with stream
+```javascript
+const readableStream = fs.createReadStream('./x.csv')
+const writableStream = ch.query ('INSERT INTO table FORMAT CSV', (err, result) => {})
+readableStream.pipe(writableStream)
+```
+
 #### Insert single row of data:
 ```javascript
 const ch = new ClickHouse(options)


### PR DESCRIPTION
- Collapse beginning and separate detailed "Synopsis" into "Examples".
Still informative for a new user, but more convenient for those already familiar.
- Extract a lot of functions usage examples into "Examples" section.
- Improve references over document.
- `Options` now presented as a table.
- Replace mentions of nonexistent `inputFormat` with `format` option and `FORMAT` statement.
- Hide dangerous for end-user option `omitFormat`. (Format detection works pretty good as for me.)
Also looks like `FORMAT` statement useful for any kind of query.
- Hide useless and confusing `syncParser` option. Provide reference and examples of promise interface instead.
- Refactor code snippets to use standard JS codestyle and ES6+ syntax, for make it easier to read.

https://github.com/apla/node-clickhouse/blob/make-readme-better/README.md