### PR TITLE
fix(clickhouse.js): remove encodeURIComponent

### DIFF
--- a/src/clickhouse.js
+++ b/src/clickhouse.js
@@ -226,9 +226,9 @@ ClickHouse.prototype.getReqParams = function () {
 	}
 
 	if (this.options.hasOwnProperty('user') || this.options.hasOwnProperty('password')) {
-		urlObject.auth = encodeURIComponent(this.options.user || 'default')
+		urlObject.auth = (this.options.user || 'default')
 			+ ':'
-			+ encodeURIComponent(this.options.password || '')
+			+ (this.options.password || '')
 	}
 
 	urlObject.method = 'POST';


### PR DESCRIPTION
Node `http.request` method use `auth` property in `options` to create base64 `Authorization` header, so encode will cause error when it includes special characters.