### PR TITLE
Add FORMAT to watch queries.

### DIFF
--- a/src/clickhouse.js
+++ b/src/clickhouse.js
@@ -284,7 +284,7 @@ ClickHouse.prototype.query = function (chQuery, options, cb) {
 	var formatEnding = '';
 
 	// format should be added for data queries
-	if (chQuery.match (/^(?:SELECT|WITH|SHOW|DESC|DESCRIBE|EXISTS\s+TABLE)/i)) {
+	if (chQuery.match (/^(?:SELECT|WITH|SHOW|WATCH|DESC|DESCRIBE|EXISTS\s+TABLE)/i)) {
 		if (!options.format)
 			options.format = options.dataObjects ? 'JSON' : 'JSONCompact';
 	} else if (chQuery.match (/^INSERT/i)) {


### PR DESCRIPTION
WATCH queries are used with LIVE VIEWS. They work like a select statement. I am using LIVE VIEWS and it took me forever to figure out why results were not streaming for this query (but did for other queries).

My workaround was to append `FORMAT JSON` to the query. This PR will allow this to happen automatically.